### PR TITLE
Enable Travis CI

### DIFF
--- a/.ci/assemble_synApps.sh
+++ b/.ci/assemble_synApps.sh
@@ -1,0 +1,173 @@
+#!/bin/bash
+shopt -s expand_aliases
+
+# This file is intended to gather everything in or used in synApps.
+# The version numbers in this file are not guaranteed to be up to date,
+# and the modules are not guaranteed to work or even build together.
+
+shallow_repo()
+{
+	PROJECT=$1
+	MODULE_NAME=$2
+	RELEASE_NAME=$3
+	TAG=$4
+	
+		FOLDER_NAME=$MODULE_NAME-${TAG/./-}
+	
+			echo
+	echo "Grabbing $MODULE_NAME at tag: $TAG"
+	echo
+	
+		if [ ! -e "$FOLDER_NAME" ] 
+	then
+		git clone --branch $TAG --depth 1 git://github.com/$PROJECT/$MODULE_NAME.git $FOLDER_NAME
+	fi
+	
+		echo "$RELEASE_NAME=\$(SUPPORT)/$FOLDER_NAME" >> ./configure/RELEASE
+	
+			echo
+}
+
+shallow_support()
+{
+	git clone --branch $2 --depth 1 git://github.com/EPICS-synApps/$1.git
+}
+
+
+alias get_support='shallow_support'
+alias get_repo='shallow_repo'
+
+cd $HOME/.cache
+
+EPICS_BASE=$HOME/.cache/base-$BASE
+
+if [ ! -e "$EPICS_BASE" ] 
+then
+	git clone --branch $BASE --depth 1 git://github.com/epics-base/epics-base.git base-$BASE
+	
+		EPICS_HOST_ARCH=`sh $EPICS_BASE/startup/EpicsHostArch`
+
+    case "$STATIC" in
+    static)
+        cat << EOF >> "$EPICS_BASE/configure/CONFIG_SITE"
+SHARED_LIBRARIES=NO
+STATIC_BUILD=YES
+EOF
+        ;;
+    *) ;;
+    esac
+
+    case "$CMPLR" in
+    clang)
+      echo "Host compiler is clang"
+      cat << EOF >> $EPICS_BASE/configure/os/CONFIG_SITE.Common.$EPICS_HOST_ARCH
+GNU         = NO
+CMPLR_CLASS = clang
+CC          = clang
+CCC         = clang++
+EOF
+      ;;
+    *) echo "Host compiler is default";;
+    esac
+
+    # requires wine and g++-mingw-w64-i686
+    if [ "$WINE" = "32" ]
+    then
+      echo "Cross mingw32"
+      sed -i -e '/CMPLR_PREFIX/d' $EPICS_BASE/configure/os/CONFIG_SITE.linux-x86.win32-x86-mingw
+      cat << EOF >> $EPICS_BASE/configure/os/CONFIG_SITE.linux-x86.win32-x86-mingw
+CMPLR_PREFIX=i686-w64-mingw32-
+EOF
+      cat << EOF >> $EPICS_BASE/configure/CONFIG_SITE
+CROSS_COMPILER_TARGET_ARCHS+=win32-x86-mingw
+EOF
+    fi
+
+    # set RTEMS to eg. "4.9" or "4.10"
+    if [ -n "$RTEMS" ]
+    then
+      echo "Cross RTEMS${RTEMS} for pc386"
+      install -d /home/travis/.cache
+      curl -L "https://github.com/mdavidsaver/rsb/releases/download/travis-20160306-2/rtems${RTEMS}-i386-trusty-20190306-2.tar.gz" \
+      | tar -C /home/travis/.cache -xj
+
+      sed -i -e '/^RTEMS_VERSION/d' -e '/^RTEMS_BASE/d' $EPICS_BASE/configure/os/CONFIG_SITE.Common.RTEMS
+      cat << EOF >> $EPICS_BASE/configure/os/CONFIG_SITE.Common.RTEMS
+RTEMS_VERSION=$RTEMS
+RTEMS_BASE=/home/travis/.cache/rtems${RTEMS}-i386
+EOF
+      cat << EOF >> $EPICS_BASE/configure/CONFIG_SITE
+CROSS_COMPILER_TARGET_ARCHS+=RTEMS-pc386
+EOF
+
+    fi
+
+    make -C "$EPICS_BASE" -j2
+    # get MSI for 3.14
+    case "$BASE" in
+    3.14*)
+        echo "Build MSI"
+        install -d "$HOME/msi/extensions/src"
+        curl https://www.aps.anl.gov/epics/download/extensions/extensionsTop_20120904.tar.gz | tar -C "$HOME/msi" -xvz
+        curl https://www.aps.anl.gov/epics/download/extensions/msi1-7.tar.gz | tar -C "$HOME/msi/extensions/src" -xvz
+        mv "$HOME/msi/extensions/src/msi1-7" "$HOME/msi/extensions/src/msi"
+
+        cat << EOF > "$HOME/msi/extensions/configure/RELEASE"
+EPICS_BASE=$EPICS_BASE
+EPICS_EXTENSIONS=\$(TOP)
+EOF
+        make -C "$HOME/msi/extensions"
+        cp "$HOME/msi/extensions/bin/$EPICS_HOST_ARCH/msi" "$EPICS_BASE/bin/$EPICS_HOST_ARCH/"
+        echo 'MSI:=$(EPICS_BASE)/bin/$(EPICS_HOST_ARCH)/msi' >> "$EPICS_BASE/configure/CONFIG_SITE"
+
+        cat <<EOF >> configure/CONFIG_SITE
+MSI = \$(EPICS_BASE)/bin/\$(EPICS_HOST_ARCH)/msi
+EOF
+
+      ;;
+    *) echo "Use MSI from Base"
+      ;;
+    esac
+fi
+
+cd $EPICS_BASE
+
+make
+
+cd ..
+
+# Assume user has nothing but this file, just in case that's true.
+mkdir synApps
+cd synApps
+
+get_support support synApps_5_8
+cd support
+
+get_support configure        synApps_5_8
+
+echo "SUPPORT=$HOME/.cache/synApps/support" > configure/RELEASE
+echo "EPICS_BASE=$EPICS_BASE" >> configure/RELEASE
+
+# modules ##################################################################
+
+if [[ $SSCAN ]]; then get_repo epics-modules    sscan            SSCAN            $SSCAN ; fi
+
+if [[ $SNCSEQ ]]
+then
+
+# seq
+wget http://www-csr.bessy.de/control/SoftDist/sequencer/releases/seq-$SNCSEQ.tar.gz
+tar zxf seq-$SNCSEQ.tar.gz
+# The synApps build can't handle '.'
+mv seq-$SNCSEQ seq-${SNCSEQ/./-}
+rm -f seq-$SNCSEQ.tar.gz
+echo 'SNCSEQ=$(SUPPORT)/seq-${SNCSEQ/./-}' >> ./configure/RELEASE
+
+fi
+
+make release
+make
+
+cp -f configure/RELEASE $TRAVIS_BUILD_DIR/configure/RELEASE
+
+cd $TRAVIS_BUILD_DIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ dist: trusty
 language: c
 compiler:
   - gcc
+notifications:
+  email: false
 cache:
   directories:
     - $HOME/.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+sudo: false
+dist: trusty
+language: c
+compiler:
+  - gcc
+cache:
+  directories:
+    - $HOME/.cache
+addons:
+  apt:
+    packages:
+    - libreadline6-dev
+    - libncurses5-dev
+    - perl
+    - clang
+    - g++-mingw-w64-i686
+    - re2c
+env:
+    - BASE=R3.15.5    STATIC=shared SSCAN=R2-10-2 SNCSEQ=2.2.4
+    - BASE=R3.14.12.6 STATIC=shared SSCAN=R2-10-2 SNCSEQ=2.2.4
+    
+before_install: chmod +x ./.ci/travis-prepare.sh
+
+install: ./.ci/travis-prepare.sh
+    
+    
+script: 
+  # Build the module
+  - make
+  - $TRAVIS_BUILD_DIR/tests/O.linux-x86_64/acalcTest
+  - $TRAVIS_BUILD_DIR/tests/O.linux-x86_64/scalcTest
+ 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,9 @@ env:
     - BASE=R3.15.5    STATIC=shared SSCAN=R2-10-2 SNCSEQ=2.2.4
     - BASE=R3.14.12.6 STATIC=shared SSCAN=R2-10-2 SNCSEQ=2.2.4
     
-before_install: chmod +x ./.ci/travis-prepare.sh
+before_install: chmod +x ./.ci/assemble_synApps.sh
 
-install: ./.ci/travis-prepare.sh
+install: ./.ci/assemble_synApps.sh
     
     
 script: 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/epics-modules/calc.svg?branch=master)](https://travis-ci.org/epics-modules/calc)
+
 # calc
 APS BCDA synApps module: calc
 


### PR DESCRIPTION
Set up automatic Travis CI builds.

Currently only building for Linux, under Base 3.15 and Base 3.14.