### PR TITLE
aCalcout.AVAL and .OAV now trigger monitors according to MDEL and ADEL

### DIFF
--- a/documentation/calcReleaseNotes.html
+++ b/documentation/calcReleaseNotes.html
@@ -9,6 +9,13 @@
 
 <h1 align="center">calc Release Notes</h1>
 
+<h2 align="center">Release X-Y</h2>
+<ul>
+<li>aCalcout now posts monitors and archive monitors for AVAL and OAV if one or
+    more their elements changes by more than MDEL or ADEL.
+</li>
+</ul>
+
 <h2 align="center">Release 3-7 (12/5/2017)</h2>
 <ul>
 <li>seq and sseq record displays now expose the SELL, SELN, and SELM fields,


### PR DESCRIPTION
Following our discussion on [this tech-talk thread](http://www.aps.anl.gov/epics/tech-talk/2017/msg01981.php).

@timmmooney 