### PR TITLE
RELEASE.local and Freescale Linux CC issue on acalcTest

### DIFF
--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -23,3 +23,8 @@ EPICS_BASE=/home/oxygen/MOONEY/epics/bazaar/base-3.14
 #Capfast users may need the following definitions
 #CAPFAST_TEMPLATES=
 #SCH2EDIF_PATH=
+
+
+# The definitions shown below can also be placed in an untracked RELEASE.local
+-include $(TOP)/../RELEASE.local
+-include $(TOP)/configure/RELEASE.local

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -21,6 +21,14 @@ calcTestHarness_SRCS += $(testHarness_SRCS)
 TESTSPEC_vxWorks = calcTestHarness.munch; runTests
 
 PROD_LIBS += calc
+
+ifdef SSCAN
+PROD_LIBS += sscan
+endif
+ifdef SNCSEQ
+PROD_LIBS += seq
+endif
+
 PROD_LIBS += $(EPICS_BASE_IOC_LIBS)
 
 TESTSCRIPTS_HOST += $(TESTS:%=%.t)


### PR DESCRIPTION
Two things I would like to discuss : 

1) RELEASE.local
   What about the RELEASE.local files in the same way CONFIG_SITE.local files ?

2) cross compilation for acalcTest 

  Enable SSCAN and SNCSEQ, strangely, I only fail to compile acalcTest with CC, it works fine with host arch (linux-x86_64) as follows:

```
/opt/fsl-qoriq/current/sysroots/x86_64-fslsdk-linux/usr/bin/powerpc64-fsl-linux/powerpc64-fsl-linux-g++ -o acalcTest  -L/testing/epics/base-3.15.5/epics-modules/calc/lib/linux-ppc64e6500 -L/testing/epics/base-3.15.5/lib/linux-ppc64e6500 -Wl,-rpath,/testing/epics/base-3.15.5/epics-modules/calc/lib/linux-ppc64e6500 -Wl,-rpath,/testing/epics/base-3.15.5/lib/linux-ppc64e6500        -m64 --sysroot=/opt/fsl-qoriq/current/sysroots/ppc64e6500-fsl-linux  -Wl,-O1 -Wl,--hash-style=gnu -Wl,--as-needed    -rdynamic -L/opt/fsl-qoriq/current/sysroots/x86_64-fslsdk-linux/usr/lib           acalcTest.o    -lcalc -ldbRecStd -ldbCore -lca -lCom   

/opt/fsl-qoriq/2.0/sysroots/x86_64-fslsdk-linux/usr/libexec/powerpc64-fsl-linux/gcc/powerpc64-fsl-linux/4.9.2/real-ld: warning: libsscan.so, needed by /testing/epics/base-3.15.5/epics-modules/calc/lib/linux-ppc64e6500/libcalc.so, not found (try using -rpath or -rpath-link)
/opt/fsl-qoriq/2.0/sysroots/x86_64-fslsdk-linux/usr/libexec/powerpc64-fsl-linux/gcc/powerpc64-fsl-linux/4.9.2/real-ld: warning: libseq.so, needed by /testing/epics/base-3.15.5/epics-modules/calc/lib/linux-ppc64e6500/libcalc.so, not found (try using -rpath or -rpath-link)
```

I added that dependency in makefile in order to link sscan and seq with calc. Then it compiles without any issue. What do you think about them?  

```
/opt/fsl-qoriq/current/sysroots/x86_64-fslsdk-linux/usr/bin/powerpc64-fsl-linux/powerpc64-fsl-linux-g++ -o scalcTest  -L/testing/epics/base-3.15.5/epics-modules/calc/lib/linux-ppc64e6500 -L/testing/epics/base-3.15.5/epics-modules/seq/lib/linux-ppc64e6500 -L/testing/epics/base-3.15.5/epics-modules/sscan/lib/linux-ppc64e6500 -L/testing/epics/base-3.15.5/lib/linux-ppc64e6500 -Wl,-rpath,/testing/epics/base-3.15.5/epics-modules/calc/lib/linux-ppc64e6500 -Wl,-rpath,/testing/epics/base-3.15.5/epics-modules/seq/lib/linux-ppc64e6500 -Wl,-rpath,/testing/epics/base-3.15.5/epics-modules/sscan/lib/linux-ppc64e6500 -Wl,-rpath,/testing/epics/base-3.15.5/lib/linux-ppc64e6500        -m64 --sysroot=/opt/fsl-qoriq/current/sysroots/ppc64e6500-fsl-linux  -Wl,-O1 -Wl,--hash-style=gnu -Wl,--as-needed    -rdynamic -L/opt/fsl-qoriq/current/sysroots/x86_64-fslsdk-linux/usr/lib           scalcTest.o    -lcalc -lsscan -lseq -ldbRecStd -ldbCore -lca -lCom 
```