### PR TITLE
Change sseq_settings.req to sseqRecord_settings.req

### DIFF
--- a/calcApp/Db/userStringSeqs10_settings.req
+++ b/calcApp/Db/userStringSeqs10_settings.req
@@ -1,25 +1,25 @@
 # FILE... userStringSeqs10_settings.req
 # USAGE.. userStringSeqs10.db fields autosave'd.
 
-file sseq_settings.req P=$(P),S=userStringSeq1
+file sseqRecord_settings.req P=$(P),S=userStringSeq1
 $(P)userStringSeq1Enable
-file sseq_settings.req P=$(P),S=userStringSeq2
+file sseqRecord_settings.req P=$(P),S=userStringSeq2
 $(P)userStringSeq2Enable
-file sseq_settings.req P=$(P),S=userStringSeq3
+file sseqRecord_settings.req P=$(P),S=userStringSeq3
 $(P)userStringSeq3Enable
-file sseq_settings.req P=$(P),S=userStringSeq4
+file sseqRecord_settings.req P=$(P),S=userStringSeq4
 $(P)userStringSeq4Enable
-file sseq_settings.req P=$(P),S=userStringSeq5
+file sseqRecord_settings.req P=$(P),S=userStringSeq5
 $(P)userStringSeq5Enable
-file sseq_settings.req P=$(P),S=userStringSeq6
+file sseqRecord_settings.req P=$(P),S=userStringSeq6
 $(P)userStringSeq6Enable
-file sseq_settings.req P=$(P),S=userStringSeq7
+file sseqRecord_settings.req P=$(P),S=userStringSeq7
 $(P)userStringSeq7Enable
-file sseq_settings.req P=$(P),S=userStringSeq8
+file sseqRecord_settings.req P=$(P),S=userStringSeq8
 $(P)userStringSeq8Enable
-file sseq_settings.req P=$(P),S=userStringSeq9
+file sseqRecord_settings.req P=$(P),S=userStringSeq9
 $(P)userStringSeq9Enable
-file sseq_settings.req P=$(P),S=userStringSeq10
+file sseqRecord_settings.req P=$(P),S=userStringSeq10
 $(P)userStringSeq10Enable
 
 $(P)userStringSeqEnable

--- a/calcApp/Db/userStringSeqs10more_settings.req
+++ b/calcApp/Db/userStringSeqs10more_settings.req
@@ -1,25 +1,25 @@
 # FILE... userStringSeqs10_settings.req
 # USAGE.. file userStringSeqs10_settings.req P=$(P),N1=11,N2=12,N3=13,N4=14,N5=15,N6=16,N7=17,N8=18,N9=19,N10=20
 
-file sseq_settings.req P=$(P),S=userStringSeq$(N1)
+file sseqRecord_settings.req P=$(P),S=userStringSeq$(N1)
 $(P)userStringSeq$(N1)Enable
-file sseq_settings.req P=$(P),S=userStringSeq$(N2)
+file sseqRecord_settings.req P=$(P),S=userStringSeq$(N2)
 $(P)userStringSeq$(N2)Enable
-file sseq_settings.req P=$(P),S=userStringSeq$(N3)
+file sseqRecord_settings.req P=$(P),S=userStringSeq$(N3)
 $(P)userStringSeq$(N3)Enable
-file sseq_settings.req P=$(P),S=userStringSeq$(N4)
+file sseqRecord_settings.req P=$(P),S=userStringSeq$(N4)
 $(P)userStringSeq$(N4)Enable
-file sseq_settings.req P=$(P),S=userStringSeq$(N5)
+file sseqRecord_settings.req P=$(P),S=userStringSeq$(N5)
 $(P)userStringSeq$(N5)Enable
-file sseq_settings.req P=$(P),S=userStringSeq$(N6)
+file sseqRecord_settings.req P=$(P),S=userStringSeq$(N6)
 $(P)userStringSeq$(N6)Enable
-file sseq_settings.req P=$(P),S=userStringSeq$(N7)
+file sseqRecord_settings.req P=$(P),S=userStringSeq$(N7)
 $(P)userStringSeq$(N7)Enable
-file sseq_settings.req P=$(P),S=userStringSeq$(N8)
+file sseqRecord_settings.req P=$(P),S=userStringSeq$(N8)
 $(P)userStringSeq$(N8)Enable
-file sseq_settings.req P=$(P),S=userStringSeq$(N9)
+file sseqRecord_settings.req P=$(P),S=userStringSeq$(N9)
 $(P)userStringSeq$(N9)Enable
-file sseq_settings.req P=$(P),S=userStringSeq$(N10)
+file sseqRecord_settings.req P=$(P),S=userStringSeq$(N10)
 $(P)userStringSeq$(N10)Enable
 
 


### PR DESCRIPTION
This has to be done since the sseq_settings file is deprecated.

Based on https://github.com/areaDetector/ADCore/issues/529. I haven't tested it, but since the file content is the same, I'm just assuming that the change is very direct.