### PR TITLE
Fix numerous build errors when building with -std=c23

### DIFF
--- a/calcApp/src/aCalcoutRecord.c
+++ b/calcApp/src/aCalcoutRecord.c
@@ -66,21 +66,21 @@
 /* Create RSET - Record Support Entry Table*/
 #define report NULL
 #define initialize NULL
-static long init_record();
-static long process();
-static long special();
+static long init_record(dbCommon *precord, int pas);
+static long process(dbCommon *precord);
+static long special(DBADDR *paddr, int after);
 #define get_value NULL
-static long cvt_dbaddr();
-static long get_array_info();
-static long put_array_info();
-static long get_units();
-static long get_precision();
+static long cvt_dbaddr(dbAddr *paddr);
+static long get_array_info(struct dbAddr *paddr, long*, long*);
+static long put_array_info(struct dbAddr *paddr, long);
+static long get_units(dbAddr *paddr, char *units);
+static long get_precision(const dbAddr *paddr, long *pprec);
 #define get_enum_str NULL
 #define get_enum_strs NULL
 #define put_enum_str NULL
-static long get_graphic_double();
-static long get_control_double();
-static long get_alarm_double();
+static long get_graphic_double(dbAddr *paddr, struct dbr_grDouble *pgd);
+static long get_control_double(dbAddr *paddr, struct dbr_ctrlDouble *pcd);
+static long get_alarm_double(dbAddr *paddr, struct dbr_alDouble *pad);
 
 rset acalcoutRSET={
 	RSETNUMBER,
@@ -138,18 +138,20 @@ typedef struct rpvtStruct {
 	short		outlink_field_type;
 } rpvtStruct;
 
-static void checkAlarms();
-static void monitor();
-static int fetch_values();
-static void execOutput();
-static void checkLinks();
-static void checkLinksCallback();
+static void checkAlarms(acalcoutRecord *pcalc);
+static void monitor(acalcoutRecord *pcalc);
+static int fetch_values(acalcoutRecord *pcalc);
+static void execOutput(acalcoutRecord *pcalc);
+static void checkLinks(acalcoutRecord *pcalc);
+static void checkLinksCallback(CALLBACK *callback);
 static long writeValue(acalcoutRecord *pcalc);
 static void call_aCalcPerform(acalcoutRecord *pcalc);
 static long doCalc(acalcoutRecord *pcalc);
 static void acalcPerformTask(void *parm);
 volatile int aCalcoutRecordDebug = 0;
 epicsExportAddress(int, aCalcoutRecordDebug);
+
+typedef long(*typed_devsupfun_t)(void*);
 
 #define MAX_FIELDS 12
 #define ARRAY_MAX_FIELDS 12
@@ -166,7 +168,7 @@ static long acalcGetNumElements( acalcoutRecord *pcalc )
 }
 
 
-static long init_record(acalcoutRecord *pcalc, int pass)
+static long init_record(dbCommon *precord, int pass)
 {
 	DBLINK *plink;
 	int i;
@@ -174,6 +176,7 @@ static long init_record(acalcoutRecord *pcalc, int pass)
 	unsigned short *plinkValid;
 	short error_number;
     acalcoutDSET *pacalcoutDSET;
+	acalcoutRecord *pcalc = (acalcoutRecord*)precord;
 
 	dbAddr       Addr;
 	dbAddr       *pAddr = &Addr;
@@ -268,7 +271,7 @@ static long init_record(acalcoutRecord *pcalc, int pass)
 	}
 
 	if (pacalcoutDSET->init_record ) {
-		return (*pacalcoutDSET->init_record)(pcalc);
+		return ((typed_devsupfun_t)pacalcoutDSET->init_record)(pcalc);
 	}
 	return(0);
 }
@@ -357,8 +360,9 @@ static long afterCalc(acalcoutRecord *pcalc) {
 	return(SYNC);
 }
 
-static long process(acalcoutRecord *pcalc)
+static long process(dbCommon *precord)
 {
+	acalcoutRecord *pcalc = (acalcoutRecord*)precord;
 	rpvtStruct   *prpvt = (rpvtStruct *)pcalc->rpvt;
 	long		i;
 	double		*pnew, *pprev;
@@ -744,7 +748,7 @@ static long get_units(dbAddr *paddr, char *units)
 	return(0);
 }
 
-static long get_precision(dbAddr *paddr, long *precision)
+static long get_precision(const dbAddr *paddr, long *precision)
 {
 	acalcoutRecord	*pcalc=(acalcoutRecord *)paddr->precord;
 	int fieldIndex = dbGetFieldIndex(paddr);
@@ -1219,7 +1223,7 @@ static long writeValue(acalcoutRecord *pcalc)
     }
 	if (aCalcoutRecordDebug >= 10)
 		printf("acalcoutRecord(%s):writeValue:calling device support\n", pcalc->name);
-	return pacalcoutDSET->write(pcalc);
+	return ((typed_devsupfun_t)pacalcoutDSET->write)(pcalc);
 }
 
 /************************************************************/

--- a/calcApp/src/devaCalcoutSoft.c
+++ b/calcApp/src/devaCalcoutSoft.c
@@ -55,7 +55,7 @@ struct {
 	NULL,
 	NULL,
 	NULL,
-	write_acalcout
+	(DEVSUPFUN)write_acalcout
 };
 epicsExportAddress(dset,devaCalcoutSoft);
 

--- a/calcApp/src/devsCalcoutSoft.c
+++ b/calcApp/src/devsCalcoutSoft.c
@@ -56,7 +56,7 @@ struct {
 	NULL,
 	NULL,
 	NULL,
-	write_scalcout
+	(DEVSUPFUN)write_scalcout
 };
 epicsExportAddress(dset,devsCalcoutSoft);
 

--- a/calcApp/src/sCalcoutRecord.c
+++ b/calcApp/src/sCalcoutRecord.c
@@ -94,21 +94,21 @@
 /* Create RSET - Record Support Entry Table*/
 #define report NULL
 #define initialize NULL
-static long init_record();
-static long process();
-static long special();
+static long init_record(dbCommon *precord, int pass);
+static long process(dbCommon *precord);
+static long special(DBADDR *paddr, int after);
 #define get_value NULL
-static long cvt_dbaddr();
+static long cvt_dbaddr(dbAddr *paddr);
 #define get_array_info NULL
 #define put_array_info NULL
-static long get_units();
-static long get_precision();
+static long get_units(dbAddr *paddr, char *units);
+static long get_precision(const dbAddr *paddr, long *prec);
 #define get_enum_str NULL
 #define get_enum_strs NULL
 #define put_enum_str NULL
-static long get_graphic_double();
-static long get_control_double();
-static long get_alarm_double();
+static long get_graphic_double(dbAddr *paddr, struct dbr_grDouble *pgd);
+static long get_control_double(dbAddr *paddr, struct dbr_ctrlDouble *pcd);
+static long get_alarm_double(dbAddr *paddr, struct dbr_alDouble *pad);
 
 rset scalcoutRSET={
 	RSETNUMBER,
@@ -175,13 +175,15 @@ typedef struct rpvtStruct {
 	short		outlink_field_type;
 } rpvtStruct;
 
-static void checkAlarms();
-static void monitor();
-static int fetch_values();
-static void execOutput();
-static void checkLinks();
-static void checkLinksCallback();
+static void checkAlarms(scalcoutRecord *pcalc);
+static void monitor(scalcoutRecord *pcalc);
+static int fetch_values(scalcoutRecord *pcalc);
+static void execOutput(scalcoutRecord *pcalc);
+static void checkLinks(scalcoutRecord *pcalc);
+static void checkLinksCallback(CALLBACK *pcallback);
 static long writeValue(scalcoutRecord *pcalc);
+
+typedef long(*typed_devsupfun_t)(void*);
 
 volatile int    sCalcoutRecordDebug = 0;
 epicsExportAddress(int, sCalcoutRecordDebug);
@@ -198,7 +200,7 @@ epicsExportAddress(int, sCalcoutRecordDebug);
 static char sFldnames[MAX_FIELDS][3] =
 {"AA","BB","CC","DD","EE","FF","GG","HH","II","JJ","KK","LL"};
 
-static long init_record(scalcoutRecord *pcalc, int pass)
+static long init_record(dbCommon *precord, int pass)
 {
 	DBLINK *plink;
 	int i;
@@ -207,6 +209,7 @@ static long init_record(scalcoutRecord *pcalc, int pass)
 	short error_number;
 	char *s, **ps;
     scalcoutDSET *pscalcoutDSET;
+	scalcoutRecord* pcalc = (scalcoutRecord*)precord;
 
 	dbAddr       Addr;
 	dbAddr       *pAddr = &Addr;
@@ -311,13 +314,14 @@ static long init_record(scalcoutRecord *pcalc, int pass)
 	}
 
 	if (pscalcoutDSET->init_record ) {
-		return (*pscalcoutDSET->init_record)(pcalc);
+		return ((typed_devsupfun_t)pscalcoutDSET->init_record)(pcalc);
 	}
     return(0);
 }
 
-static long process(scalcoutRecord *pcalc)
+static long process(dbCommon *precord)
 {
+	scalcoutRecord *pcalc = (scalcoutRecord*)precord;
 	rpvtStruct   *prpvt = (rpvtStruct *)pcalc->rpvt;
 	short		doOutput = 0;
 	long		stat;
@@ -604,7 +608,7 @@ static long get_units(dbAddr *paddr, char *units)
 	return(0);
 }
 
-static long get_precision(dbAddr *paddr, long *precision)
+static long get_precision(const dbAddr *paddr, long *precision)
 {
 	scalcoutRecord	*pcalc=(scalcoutRecord *)paddr->precord;
 	int fieldIndex = dbGetFieldIndex(paddr);
@@ -1071,5 +1075,6 @@ static long writeValue(scalcoutRecord *pcalc)
         pcalc->pact = TRUE;
         return(-1);
     }
-	return pscalcoutDSET->write(pcalc);
+
+	return ((typed_devsupfun_t)pscalcoutDSET->write)(pcalc);
 }

--- a/calcApp/src/swaitRecord.c
+++ b/calcApp/src/swaitRecord.c
@@ -182,7 +182,7 @@ WAIT_IO_EVENT devSWaitIoEvent = {
         NULL,
         NULL,
         NULL,
-        get_ioint_info,
+        (DEVSUPFUN)get_ioint_info,
         NULL
 };
 epicsExportAddress(dset, devSWaitIoEvent);

--- a/calcApp/src/transformRecord.c
+++ b/calcApp/src/transformRecord.c
@@ -144,15 +144,15 @@ epicsExportAddress(int, transformRecordDebug);
 /* Create RSET - Record Support Entry Table*/
 #define report NULL
 #define initialize NULL
-static long     init_record();
-static long     process();
-static long     special();
+static long     init_record(dbCommon *precord, int pass);
+static long     process(dbCommon *precord);
+static long     special(DBADDR* paddr, int after);
 #define get_value NULL
 #define cvt_dbaddr NULL
 #define get_array_info NULL
 #define put_array_info NULL
 #define get_units NULL
-static long     get_precision();
+static long     get_precision(const DBADDR *addr, long *pprec);
 #define get_enum_str NULL
 #define get_enum_strs NULL
 #define put_enum_str NULL
@@ -182,8 +182,8 @@ rset    transformRSET = {
 };
 epicsExportAddress(rset, transformRSET);
 
-static void     checkAlarms();
-static void     monitor();
+static void     checkAlarms(transformRecord *precord);
+static void     monitor(transformRecord *precord);
 
 /* To provide feedback to the user as to the connection status of the 
  * links (.IxV and .OxV), the following algorithm has been implemented ...
@@ -197,8 +197,8 @@ static void     monitor();
  * (This code stolen from Ned Arnold's calcAo record.)
  */
 
-static void checkLinksCallback();
-static void checkLinks();
+static void checkLinksCallback(CALLBACK *pcallback);
+static void checkLinks(struct transformRecord *precord);
 #define NO_CA_LINKS     0
 #define CA_LINKS_ALL_OK 1
 #define CA_LINKS_NOT_OK 2
@@ -625,7 +625,7 @@ process(dbCommon *pcommon)
 
 
 static long 
-special(const DBADDR *paddr, int after)
+special(DBADDR *paddr, int after)
 {
 	int				i;
 	transformRecord	*ptran = (transformRecord *) (paddr->precord);


### PR DESCRIPTION
Incompatible pointers are errors by default in C23, and those old style implicit function declarations were removed.