### PR TITLE
sCalc: fix out-of-bounds read in lrc() on an empty operand

### DIFF
--- a/calcApp/src/sCalcPerform.c
+++ b/calcApp/src/sCalcPerform.c
@@ -241,10 +241,14 @@ int hex(char c) {
 
 int lrc(char *output, char *rawInput)
 {
-	int i;
+	int i, len;
 	unsigned int lrc;
 
-	for (i=0, lrc=0; i<strlen(rawInput)-1; i+=2) {
+	/* strlen() is size_t; for an empty operand strlen(rawInput)-1 would
+	 * wrap to SIZE_MAX and the loop would read out of bounds.  Compare
+	 * against a signed length so an empty string yields an empty loop. */
+	len = (int)strlen(rawInput);
+	for (i=0, lrc=0; i+1<len; i+=2) {
 		lrc += hex(rawInput[i])*0x10 + hex(rawInput[i+1]);
 		if (sCalcPerformDebug>=20) printf("lrc: adding %d\n", rawInput[i]*0x10 + rawInput[i+1]);
 	}

--- a/tests/scalcTest.cpp
+++ b/tests/scalcTest.cpp
@@ -106,7 +106,7 @@ MAIN(scalcTest)
 	double args[12] = {A, B, C, D, E, F, G, H, I, J, K, L};
 	const char* sargs[12] = {AA, BB, CC, DD, EE, FF, GG, HH, II, JJ, KK, LL};
 	
-	testPlan(143);
+	testPlan(145);
 
 	testValExpr("finite(1)", args, sargs, 1);
 	testValExpr("isnan(1)", args, sargs, 0);
@@ -288,6 +288,12 @@ MAIN(scalcTest)
 	/* String subtract-first and subtract-last */
 	testSValExpr("'abca'-|'a'", args, sargs, "bca");
 	testSValExpr("'abca'|-'a'", args, sargs, "abc");
+
+	/* LRC on an empty operand: strlen(rawInput)-1 must not wrap size_t and
+	 * read out of bounds.  Empty -> empty loop -> lrc 0 -> "00".
+	 * The documented AMODBUS example "F7031389000A" has LRC 0x60. */
+	testSValExpr("LRC('')", args, sargs, "00");
+	testSValExpr("LRC('F7031389000A')", args, sargs, "60");
 	
 	/* UNTIL loops */
 	testValExpr("UNTIL(1)", args, sargs, 1.0);


### PR DESCRIPTION
### Problem

`lrc()` in `sCalcPerform.c` loops with

```c
for (i=0, lrc=0; i<strlen(rawInput)-1; i+=2) {
    lrc += hex(rawInput[i])*0x10 + hex(rawInput[i+1]);
```

`strlen()` returns `size_t` (unsigned). For an **empty operand**,
`strlen(rawInput)-1` wraps to `SIZE_MAX`, so `i < SIZE_MAX` is always
true and the loop reads `rawInput[]` far out of bounds.

The `LRC` and `AMODBUS` operators call `lrc()` with whatever string is
on the stack (`case LRC:` / `case AMODBUS:` in `sCalcPerform.c`), so an
scalcout expression like `LRC('')` — or `LRC` applied to an empty
string field — crashes the IOC with **SIGSEGV**.

### Fix

Compute the length once into a signed `int` and loop while `i+1 < len`.
An empty operand now yields an empty loop (LRC `"00"`); non-empty
operands are unchanged. The sibling `xor8()` already guards `len == 0`;
this brings `lrc()` in line.

### Test

Adds two `scalcTest` cases:

- `LRC('')` → `"00"`
- `LRC('F7031389000A')` → `"60"` (the LRC `0x60` from the AMODBUS
  worked example in the source comment)

Without the fix `scalcTest` terminates with SIGSEGV on the empty-operand
case; with the fix the full suite passes (145/145).